### PR TITLE
sitemap

### DIFF
--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,40 +1,20 @@
 import { appUrl } from "app/layout/components/DefaultHead/DefaultHead"
-// import fetcher from "@utils/fetcher"
-// import { GetServerSideProps } from "next"
 
 function generateSiteMap() {
   return `<?xml version="1.0" encoding="UTF-8"?>
    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-     <url>
+      <url>
         <loc>${appUrl}</loc>
+      </url>
+      <url>
+        <loc>${appUrl}/submit</loc>
       </url>
    </urlset>
  `
 }
 
 function SiteMap() {
-  // getServerSideProps will do the heavy lifting
   return generateSiteMap()
 }
-
-// export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
-//   const baseUrl = process.env.NEXT_PUBLIC_APP_URL
-//   // const { dynamicContent } = await fetcher(`${baseUrl}/`)
-
-//   // We generate the XML sitemap with the posts data
-//   // const sitemap = generateSiteMap(dynamicContent)
-
-//   // or with static data
-//   const sitemap = generateSiteMap()
-
-//   res.setHeader("Content-Type", "text/xml")
-//   // we send the XML to the browser
-//   res.write(sitemap)
-//   res.end()
-
-//   return {
-//     props: {}
-//   }
-// }
 
 export default SiteMap

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,6 +1,6 @@
 import { appUrl } from "app/layout/components/DefaultHead/DefaultHead"
 // import fetcher from "@utils/fetcher"
-import { GetServerSideProps } from "next"
+// import { GetServerSideProps } from "next"
 
 function generateSiteMap() {
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -14,26 +14,27 @@ function generateSiteMap() {
 
 function SiteMap() {
   // getServerSideProps will do the heavy lifting
+  return generateSiteMap()
 }
 
-export const getServerSideProps: GetServerSideProps = async ({ res }) => {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL
-  // const { dynamicContent } = await fetcher(`${baseUrl}/`)
+// export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+//   const baseUrl = process.env.NEXT_PUBLIC_APP_URL
+//   // const { dynamicContent } = await fetcher(`${baseUrl}/`)
 
-  // We generate the XML sitemap with the posts data
-  // const sitemap = generateSiteMap(dynamicContent)
+//   // We generate the XML sitemap with the posts data
+//   // const sitemap = generateSiteMap(dynamicContent)
 
-  // or with static data
-  const sitemap = generateSiteMap()
+//   // or with static data
+//   const sitemap = generateSiteMap()
 
-  res.setHeader("Content-Type", "text/xml")
-  // we send the XML to the browser
-  res.write(sitemap)
-  res.end()
+//   res.setHeader("Content-Type", "text/xml")
+//   // we send the XML to the browser
+//   res.write(sitemap)
+//   res.end()
 
-  return {
-    props: {}
-  }
-}
+//   return {
+//     props: {}
+//   }
+// }
 
 export default SiteMap


### PR DESCRIPTION
`TypeError: res.setHeader is not a function`

res.method inside the getServerSideProps returns 500 error.
This is a super quick temporary fix, there is no reason atm to use getServerSideProps, it is just commented out.
